### PR TITLE
Skip <Arduino.h> while parsing

### DIFF
--- a/arduino-manifest.pl
+++ b/arduino-manifest.pl
@@ -125,9 +125,13 @@ print STDERR "\nInclude files:\n" if ($debug);
 # read '#include <...>" lines from input files
 while (<>) {
     if (/^\s*\#include\s+\<([^\>]+)/) {
-	$includef=$1;
-	print STDERR "  $includef \n" if ($debug);
-	$includef{$includef}=1;
+        # Skip the default Arduino header since it will never be a requirement.
+        if ($1 == "Arduino.h") {
+            next;
+        }
+        $includef=$1;
+        print STDERR "  $includef \n" if ($debug);
+        $includef{$includef}=1;
     }
 }
 


### PR DESCRIPTION
I'm working on personal project and use VSCode. I have to include #include <Arduino.h> to get the auto complete to work right. This unfortunately means I will get the following in my stderr when using the script. 
```
  NOT FOUND: Arduino.h
```   
It still works, but I do not consider this an error. Anyway my PR here just hardcodes to skip it since it will never be a requirement.
